### PR TITLE
Highlight IncSearch with reversed Search color

### DIFF
--- a/colors/monotone.vim
+++ b/colors/monotone.vim
@@ -133,6 +133,7 @@ function s:MonotoneColors(color, secondary_hue_offset, emphasize_comments, empha
 	call s:Hi('CursorLineNr', s:color_bright_2, s:color_dark_1, 'NONE', 235, 'NONE')
 	call s:Hi('Folded', s:color_normal, s:color_dark_1, 252, 235, 'italic')
 	call s:Hi('Search', s:color_dark_3, s:color_hl_2, 16, 214, 'bold')
+	call s:Hi('IncSearch', s:color_dark_3, s:color_hl_2, 16, 214, 'bold,reverse')
 	call s:Hi('LineNr', s:color_bright_0, 'NONE', 240, 'NONE', 'NONE')
 	call s:Hi('VertSplit', s:color_bright_0, 'NONE', 240, 'NONE', 'NONE')
 	call s:Hi('WildMenu', s:color_dark_3, s:color_normal, 16, 248, 'NONE')


### PR DESCRIPTION
The purpose of highlighting `IncSearch` is to easily find by visual inspection which match is currently selected when running a substitution command with confirmation:
```
:%s/foo/bar/gc
```

I used the reverse of the `Search` highlight color. It is the same color as the cursor when it is on top of a regular search result.

I think it works out pretty well but I'm happy to hear other opinions. I only tried it with my settings (`Monotone 44 97 68 0 0 0 0.85`), and the default settings.

This is also discussed in issue #13.