### PR TITLE
Invert matching pairs highlighting

### DIFF
--- a/colors/monotone.vim
+++ b/colors/monotone.vim
@@ -149,7 +149,7 @@ function s:MonotoneColors(color, secondary_hue_offset, emphasize_comments, empha
 	call s:Hi('MoreMsg', s:color_hl_3, 'NONE', 153, 'NONE', 'bold')
 
 	" Parens
-	call s:Hi('MatchParen', s:color_dark_3, s:color_hl_2, 16, 214, 'NONE')
+	call s:Hi('MatchParen', s:color_hl_2, s:color_dark_3, 214, 16, 'NONE')
 	hi link ParenMatch MatchParen
 
 	" Popup menu


### PR DESCRIPTION
This has been a pain until I changed it : parenthesis under the cursor highlight is *not* "video inverted" (or negative, or whatever you call it) in normal mode as is the cursor everywhere else. 

I almost always confuse it with its matching char, which *is* inverted.

So this inverts `MatchParen` highlighting so that parenthesis under the cursor is inverted in normal mode. 

First parenthesis is under the cursor in below screen. Without this PR, it would have been the last one.
![image](https://user-images.githubusercontent.com/4181623/133439767-90408ee8-3835-493b-bee6-6aace7baa305.png)

Still a little issue though, it looses the IncSearch inversion when you search for a string starting with a pairing character.
