### PR TITLE
Fix switch/reload colorscheme

### DIFF
--- a/colors/monotone.vim
+++ b/colors/monotone.vim
@@ -23,6 +23,12 @@
 " IN THE SOFTWARE.
 
 if exists('g:loaded_monotone')
+	call s:MonotoneColors(
+		\ g:monotone_color,
+		\ g:monotone_secondary_hue_offset,
+		\ g:monotone_emphasize_comments,
+		\ g:monotone_emphasize_whitespace,
+		\ g:monotone_contrast_factor)
 	finish
 endif
 if !exists('g:monotone_color')


### PR DESCRIPTION
Calling `:colorscheme monotone` several times doesn't always do the same thing, which is surprising.
As implemented, the load guard prevents the user from switching to another color scheme and back, or from reloading monotone.

This PR updates the load guard to reapply the color scheme even if it has already been previously loaded.